### PR TITLE
Fix 'use of local variable before it has been assigned' error

### DIFF
--- a/services/channel4/channel4.py
+++ b/services/channel4/channel4.py
@@ -354,13 +354,13 @@ class CHANNEL4(Config):
             b_manifest, b_token, b_subtitle = web_assets
             web_heights = self.get_heights(b_manifest, client="WEB")
 
-        if not android_heights and not web_heights:
+        if (not ('android_heights' in locals())) and (not ('web_heights' in locals())):
             self.log.error(
                 "Failed to request manifest data. If you're behind a VPN/proxy, you might be blocked"
             )
             sys.exit(1)
 
-        if not android_heights or android_heights[0] < 1080:
+        if (not ('android_heights' in locals())) or android_heights[0] < 1080:
             self.log.warning(
                 "ANDROID data returned None or is missing full quality profile, falling back to WEB data..."
             )


### PR DESCRIPTION
I was getting an error where Python complained that you were trying to use android_heights and web_heights variables before they'd been assigned. This patch seems to fix it. Or I guess you could assign both variables to be None at the start of the method.